### PR TITLE
feat: Refactor project file tree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,12 @@
     "hompage": "https://www.zaikorea.org",
     "autoload": {
         "psr-4": {
-            "ZaiKorea\\": "src/"
+            "ZaiClient\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ZaiClient\\Tests\\": "tests/"
         }
     },
     "authors": [

--- a/src/Configs/Config.php
+++ b/src/Configs/Config.php
@@ -6,7 +6,7 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Configs;
+namespace ZaiClient\Configs;
 
 class Config
 {

--- a/src/Exceptions/BatchSizeLimitExceededException.php
+++ b/src/Exceptions/BatchSizeLimitExceededException.php
@@ -6,7 +6,7 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Exceptions;
+namespace ZaiClient\Exceptions;
 
 use \GuzzleHttp\Exception\BadResponseException;
 

--- a/src/Exceptions/ZaiClientException.php
+++ b/src/Exceptions/ZaiClientException.php
@@ -6,7 +6,7 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Exceptions;
+namespace ZaiClient\Exceptions;
 
 use \GuzzleHttp\Exception\RequestException;
 

--- a/src/Exceptions/ZaiNetworkIOException.php
+++ b/src/Exceptions/ZaiNetworkIOException.php
@@ -6,7 +6,7 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Exceptions;
+namespace ZaiClient\Exceptions;
 
 use \GuzzleHttp\Exception\TransferException;
 

--- a/src/Requests/BaseEvent.php
+++ b/src/Requests/BaseEvent.php
@@ -4,7 +4,7 @@
  * BaseEvent
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
 class BaseEvent
 {

--- a/src/Requests/CartaddEvent.php
+++ b/src/Requests/CartaddEvent.php
@@ -1,67 +1,66 @@
 <?php
 
 /**
- * LikeEvent
+ * CartaddEvent
  * @author Uiseop Eom <tech@zaikorea.org>
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
 
 /**
  * @final
  */
-class LikeEvent extends BaseEvent
+class CartaddEvent extends BaseEvent
 {
-    const EVENT_TYPE = 'like';
+    const EVENT_TYPE = 'cartadd';
     const EVENT_VALUE = 'null';
 
     /**
-     * LikeEvent accepts:
+     * CartaddEvent accepts:
      * - customer id
      * - single item_id or array of item_ids
      * - array of options
      *
-     * Here's an example of creating a Like event using a single
+     * Here's an example of creating a Cartadd event using a single
      * item_id or an array of item_ids * default request options to apply
      * to each request:
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
      *     $item_id = 'P1123456'
-     *     $like_event = new LikeEvent($user_id, $item_id);
+     *     $cartadd_event = new CartaddEvent($user_id, $item_id);
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
      *     $item_id = ['P11234567', 'P11234567'];
      *     $options = ['timestamp'=> 1657197315];
-     *     $like_event_batch = new LikeEvent($user_id, $item_ids, $options);
+     *     $cartadd_event_batch = new CartaddEvent($user_id, $item_ids, $options);
      *
-     * The LikeEvent class supports following options:
+     * The Cartadd class supports following options:
      *     - timesptamp: a custom timestamp given by the user, the user
      *                   can use this option to customize the timestamp
      *                   of the recorded event.
      *
      * @param int|string $user_id
-     * @param string|array $item_ids
+     * @param string $item_id
      * @param array $options
      */
     public function __construct($user_id, $item_id, $options = array())
     {
-        // $item_id should not be an emtpy array
+        // $item_id should not be an emtpy string
         if (!$item_id)
             throw new \InvalidArgumentException(
                 'Length of item id must be between 1 and 100.'
             );
-        // $page_type should not be an array (doesn't support batch)
+        // $item_id should not be an array (doesn't support batch)
         if (is_array($item_id))
             throw new \InvalidArgumentException(
                 sprintf(Config::BATCH_ERRMSG, self::class)
             );
 
-        // set timestamp to custom timestamp given by the user
         $this->setTimestamp(strval(microtime(true)));
         if (isset($options['timestamp']))
             $this->setTimestamp($options['timestamp']);

--- a/src/Requests/CustomEvent.php
+++ b/src/Requests/CustomEvent.php
@@ -6,12 +6,12 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
-use ZaiKorea\ZaiClient\Exceptions\BatchSizeLimitExceededException;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
+use ZaiClient\Exceptions\BatchSizeLimitExceededException;
 
 /**
  * @final
@@ -103,13 +103,15 @@ class CustomEvent extends BaseEvent
                     )
                 );
             }
-            array_push($events, new EventInBatch(
-                $user_id,
-                $custom_action['item_id'],
-                $tmp_timestamp,
-                $custom_event_type,
-                $custom_action['value']
-            )
+            array_push(
+                $events,
+                new EventInBatch(
+                    $user_id,
+                    $custom_action['item_id'],
+                    $tmp_timestamp,
+                    $custom_event_type,
+                    $custom_action['value']
+                )
             );
             $tmp_timestamp += Config::EPSILON;
         }

--- a/src/Requests/EventInBatch.php
+++ b/src/Requests/EventInBatch.php
@@ -6,7 +6,7 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
 /**
  * @final

--- a/src/Requests/LikeEvent.php
+++ b/src/Requests/LikeEvent.php
@@ -1,66 +1,67 @@
 <?php
 
 /**
- * CartaddEvent
+ * LikeEvent
  * @author Uiseop Eom <tech@zaikorea.org>
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
 
 /**
  * @final
  */
-class CartaddEvent extends BaseEvent
+class LikeEvent extends BaseEvent
 {
-    const EVENT_TYPE = 'cartadd';
+    const EVENT_TYPE = 'like';
     const EVENT_VALUE = 'null';
 
     /**
-     * CartaddEvent accepts:
+     * LikeEvent accepts:
      * - customer id
      * - single item_id or array of item_ids
      * - array of options
      *
-     * Here's an example of creating a Cartadd event using a single
+     * Here's an example of creating a Like event using a single
      * item_id or an array of item_ids * default request options to apply
      * to each request:
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
      *     $item_id = 'P1123456'
-     *     $cartadd_event = new CartaddEvent($user_id, $item_id);
+     *     $like_event = new LikeEvent($user_id, $item_id);
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
      *     $item_id = ['P11234567', 'P11234567'];
      *     $options = ['timestamp'=> 1657197315];
-     *     $cartadd_event_batch = new CartaddEvent($user_id, $item_ids, $options);
+     *     $like_event_batch = new LikeEvent($user_id, $item_ids, $options);
      *
-     * The Cartadd class supports following options:
+     * The LikeEvent class supports following options:
      *     - timesptamp: a custom timestamp given by the user, the user
      *                   can use this option to customize the timestamp
      *                   of the recorded event.
      *
      * @param int|string $user_id
-     * @param string $item_id
+     * @param string|array $item_ids
      * @param array $options
      */
     public function __construct($user_id, $item_id, $options = array())
     {
-        // $item_id should not be an emtpy string
+        // $item_id should not be an emtpy array
         if (!$item_id)
             throw new \InvalidArgumentException(
                 'Length of item id must be between 1 and 100.'
             );
-        // $item_id should not be an array (doesn't support batch)
+        // $page_type should not be an array (doesn't support batch)
         if (is_array($item_id))
             throw new \InvalidArgumentException(
                 sprintf(Config::BATCH_ERRMSG, self::class)
             );
 
+        // set timestamp to custom timestamp given by the user
         $this->setTimestamp(strval(microtime(true)));
         if (isset($options['timestamp']))
             $this->setTimestamp($options['timestamp']);

--- a/src/Requests/PageViewEvent.php
+++ b/src/Requests/PageViewEvent.php
@@ -1,26 +1,26 @@
 <?php
 
 /**
- * ProductDetailViewEvent
+ * PageViewEvent
  * @author Uiseop Eom <tech@zaikorea.org>
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
 
-class ProductDetailViewEvent extends BaseEvent
+class PageViewEvent extends BaseEvent
 {
-    const EVENT_TYPE = 'product_detail_view';
-    const EVENT_VALUE = 'null';
+    const EVENT_TYPE = 'page_view';
+    const ITEM_ID = 'null';
 
     /**
-     * ProductDetailViewEvent accepts:
+     * PageViewEvent accepts:
      * - customer id
-     * - single item_id or array of item_ids
+     * - single event_value or array of event_values
      * - array of options
      *
      * Here's an example of creating a View event using a single
@@ -28,33 +28,39 @@ class ProductDetailViewEvent extends BaseEvent
      * to each request:
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
-     *     $item_id = 'P1123456'
-     *     $view_event = new ProductDetailViewEvent($user_id, $item_id);
+     *     $event_value = 'homepage'
+     *     $view_event = new PageViewEvent($user_id, $event_value);
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
-     *     $item_id = ['P11234567', 'P11234567'];
+     *     $evant_values = ['homepage', 'category'];
      *     $options = ['timestamp'=> 1657197315];
-     *     $view_event_batch = new ProductDetailViewEvent($user_id, $item_ids, $options);
+     *     $view_event_batch = new PageViewEvent($user_id, $event_values, $options);
      *
-     * The ProductDetailViewEvent class supports following options:
+     * The PageViewEvent class supports following options:
      *     - timesptamp: a custom timestamp given by the user, the user
      *                   can use this option to customize the timestamp
      *                   of the recorded event.
      *
      * @param int|string $user_id
-     * @param string $item_id
+     * @param string $page_type
      * @param array $options
      */
-    public function __construct($user_id, $item_id, $options = array())
+    public function __construct($user_id, $page_type, $options = array())
     {
-        if (!$item_id)
-            throw new \InvalidArgumentException(
-                'Length of item id must be between 1 and 100.'
-            );
-        // $item_id should not be an array (doesn't support batch)
-        if (is_array($item_id))
+        // $page_type should be a string
+        if (!is_string($page_type))
             throw new \InvalidArgumentException(
                 sprintf(Config::NON_STR_ARG_ERRMSG, self::class, __FUNCTION__, 2)
+            );
+        // $page_type should be a non-empty string
+        if (!$page_type)
+            throw new \InvalidArgumentException(
+                sprintf(Config::NON_STR_ARG_ERRMSG, self::class, __FUNCTION__, 2)
+            );
+        // $page_type should not be an array (doesn't support batch)
+        if (is_array($page_type))
+            throw new \InvalidArgumentException(
+                sprintf(Config::BATCH_ERRMSG, self::class)
             );
 
         // set timestamp to custom timestamp given by the user
@@ -64,10 +70,10 @@ class ProductDetailViewEvent extends BaseEvent
 
         $event = new EventInBatch(
             $user_id,
-            $item_id,
+            self::ITEM_ID,
             $this->getTimestamp(),
             self::EVENT_TYPE,
-            self::EVENT_VALUE
+            $page_type
         );
 
         $this->setPayload($event);

--- a/src/Requests/ProductDetailViewEvent.php
+++ b/src/Requests/ProductDetailViewEvent.php
@@ -1,26 +1,26 @@
 <?php
 
 /**
- * PageViewEvent
+ * ProductDetailViewEvent
  * @author Uiseop Eom <tech@zaikorea.org>
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
 
-class PageViewEvent extends BaseEvent
+class ProductDetailViewEvent extends BaseEvent
 {
-    const EVENT_TYPE = 'page_view';
-    const ITEM_ID = 'null';
+    const EVENT_TYPE = 'product_detail_view';
+    const EVENT_VALUE = 'null';
 
     /**
-     * PageViewEvent accepts:
+     * ProductDetailViewEvent accepts:
      * - customer id
-     * - single event_value or array of event_values
+     * - single item_id or array of item_ids
      * - array of options
      *
      * Here's an example of creating a View event using a single
@@ -28,39 +28,33 @@ class PageViewEvent extends BaseEvent
      * to each request:
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
-     *     $event_value = 'homepage'
-     *     $view_event = new PageViewEvent($user_id, $event_value);
+     *     $item_id = 'P1123456'
+     *     $view_event = new ProductDetailViewEvent($user_id, $item_id);
      *
      *     $user_id = '3f672ed3-4ea2-435f-91ff-ac32a3e4d1f1'
-     *     $evant_values = ['homepage', 'category'];
+     *     $item_id = ['P11234567', 'P11234567'];
      *     $options = ['timestamp'=> 1657197315];
-     *     $view_event_batch = new PageViewEvent($user_id, $event_values, $options);
+     *     $view_event_batch = new ProductDetailViewEvent($user_id, $item_ids, $options);
      *
-     * The PageViewEvent class supports following options:
+     * The ProductDetailViewEvent class supports following options:
      *     - timesptamp: a custom timestamp given by the user, the user
      *                   can use this option to customize the timestamp
      *                   of the recorded event.
      *
      * @param int|string $user_id
-     * @param string $page_type
+     * @param string $item_id
      * @param array $options
      */
-    public function __construct($user_id, $page_type, $options = array())
+    public function __construct($user_id, $item_id, $options = array())
     {
-        // $page_type should be a string
-        if (!is_string($page_type))
+        if (!$item_id)
+            throw new \InvalidArgumentException(
+                'Length of item id must be between 1 and 100.'
+            );
+        // $item_id should not be an array (doesn't support batch)
+        if (is_array($item_id))
             throw new \InvalidArgumentException(
                 sprintf(Config::NON_STR_ARG_ERRMSG, self::class, __FUNCTION__, 2)
-            );
-        // $page_type should be a non-empty string
-        if (!$page_type)
-            throw new \InvalidArgumentException(
-                sprintf(Config::NON_STR_ARG_ERRMSG, self::class, __FUNCTION__, 2)
-            );
-        // $page_type should not be an array (doesn't support batch)
-        if (is_array($page_type))
-            throw new \InvalidArgumentException(
-                sprintf(Config::BATCH_ERRMSG, self::class)
             );
 
         // set timestamp to custom timestamp given by the user
@@ -70,10 +64,10 @@ class PageViewEvent extends BaseEvent
 
         $event = new EventInBatch(
             $user_id,
-            self::ITEM_ID,
+            $item_id,
             $this->getTimestamp(),
             self::EVENT_TYPE,
-            $page_type
+            self::EVENT_VALUE
         );
 
         $this->setPayload($event);

--- a/src/Requests/PurchaseEvent.php
+++ b/src/Requests/PurchaseEvent.php
@@ -6,12 +6,12 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
-use ZaiKorea\ZaiClient\Exceptions\BatchSizeLimitExceededException;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
+use ZaiClient\Exceptions\BatchSizeLimitExceededException;
 
 /**
  * @final
@@ -99,13 +99,15 @@ class PurchaseEvent extends BaseEvent
             }
 
             for ($i = 0; $i < $order_spec['count']; $i++) {
-                array_push($events, new EventInBatch(
-                    $user_id,
-                    $order_spec['item_id'],
-                    $tmp_timestamp,
-                    self::EVENT_TYPE,
-                    $order_spec['price']
-                )
+                array_push(
+                    $events,
+                    new EventInBatch(
+                        $user_id,
+                        $order_spec['item_id'],
+                        $tmp_timestamp,
+                        self::EVENT_TYPE,
+                        $order_spec['price']
+                    )
                 );
                 $tmp_timestamp += Config::EPSILON;
             }

--- a/src/Requests/RateEvent.php
+++ b/src/Requests/RateEvent.php
@@ -6,11 +6,11 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
 
 /**
  * @final

--- a/src/Requests/RecommendationRequest.php
+++ b/src/Requests/RecommendationRequest.php
@@ -4,7 +4,7 @@
  * Recommendation request
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
 abstract class RecommendationRequest implements \JsonSerializable
 {

--- a/src/Requests/RelatedItemsRecommendationRequest.php
+++ b/src/Requests/RelatedItemsRecommendationRequest.php
@@ -4,10 +4,10 @@
  * Recommendation request
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\RecommendationRequest;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\RecommendationRequest;
+use ZaiClient\Configs\Config;
 
 class RelatedItemsRecommendationRequest extends RecommendationRequest
 {

--- a/src/Requests/RerankingRecommendationRequest.php
+++ b/src/Requests/RerankingRecommendationRequest.php
@@ -4,10 +4,10 @@
  * Recommendation request
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\RecommendationRequest;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\RecommendationRequest;
+use ZaiClient\Configs\Config;
 
 class RerankingRecommendationRequest extends RecommendationRequest
 {

--- a/src/Requests/SearchEvent.php
+++ b/src/Requests/SearchEvent.php
@@ -6,12 +6,12 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\BaseEvent;
-use ZaiKorea\ZaiClient\Requests\EventInBatch;
-use ZaiKorea\ZaiClient\Configs\Config;
-use ZaiKorea\ZaiClient\Exceptions\BatchSizeLimitExceededException;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\EventInBatch;
+use ZaiClient\Configs\Config;
+use ZaiClient\Exceptions\BatchSizeLimitExceededException;
 
 class SearchEvent extends BaseEvent
 {
@@ -73,13 +73,15 @@ class SearchEvent extends BaseEvent
         $tmp_timestamp = $this->getTimestamp();
 
         foreach ($search_queries as $search_query) {
-            array_push($events, new EventInBatch(
-                $user_id,
-                self::ITEM_ID,
-                $tmp_timestamp,
-                self::EVENT_TYPE,
-                $search_query
-            )
+            array_push(
+                $events,
+                new EventInBatch(
+                    $user_id,
+                    self::ITEM_ID,
+                    $tmp_timestamp,
+                    self::EVENT_TYPE,
+                    $search_query
+                )
             );
             $tmp_timestamp += Config::EPSILON;
         }

--- a/src/Requests/UserRecommendationRequest.php
+++ b/src/Requests/UserRecommendationRequest.php
@@ -4,10 +4,10 @@
  * Recommendation request
  */
 
-namespace ZaiKorea\ZaiClient\Requests;
+namespace ZaiClient\Requests;
 
-use ZaiKorea\ZaiClient\Requests\RecommendationRequest;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\RecommendationRequest;
+use ZaiClient\Configs\Config;
 
 class UserRecommendationRequest extends RecommendationRequest
 {

--- a/src/Responses/EventLoggerResponse.php
+++ b/src/Responses/EventLoggerResponse.php
@@ -4,7 +4,7 @@
  * EventLogger response
  */
 
-namespace ZaiKorea\ZaiClient\Responses;
+namespace ZaiClient\Responses;
 
 class EventLoggerResponse
 {

--- a/src/Responses/RecommendationResponse.php
+++ b/src/Responses/RecommendationResponse.php
@@ -7,7 +7,7 @@
  * https://github.com/cweiske/jsonmapper/issues/41
  */
 
-namespace ZaiKorea\ZaiClient\Responses;
+namespace ZaiClient\Responses;
 
 class RecommendationResponse
 {

--- a/src/Security/ZaiHeaders.php
+++ b/src/Security/ZaiHeaders.php
@@ -5,9 +5,9 @@
  * @author Uiseop Eom <tech@zaikorea.org>
  */
 
-namespace ZaiKorea\ZaiClient\Security;
+namespace ZaiClient\Security;
 
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Configs\Config;
 
 /**
  * Utils

--- a/src/ZaiClient.php
+++ b/src/ZaiClient.php
@@ -6,21 +6,20 @@
  */
 
 
-namespace ZaiKorea\ZaiClient;
+namespace ZaiClient;
 
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
-use ZaiKorea\ZaiClient\Requests\RecommendationRequest;
-use ZaiKorea\ZaiClient\Responses\RecommendationResponse;
-use ZaiKorea\ZaiClient\Responses\EventLoggerResponse;
-use ZaiKorea\ZaiClient\Security\ZaiHeaders;
-use ZaiKorea\ZaiClient\Exceptions\ZaiClientException;
-use ZaiKorea\ZaiClient\Exceptions\ZaiNetworkIOException;
-
+use GuzzleHttp\Psr7\Utils;
 use JsonMapper;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Configs\Config;
+use ZaiClient\Exceptions\ZaiClientException;
+use ZaiClient\Exceptions\ZaiNetworkIOException;
+use ZaiClient\Requests\BaseEvent;
+use ZaiClient\Requests\RecommendationRequest;
+use ZaiClient\Responses\EventLoggerResponse;
+use ZaiClient\Responses\RecommendationResponse;
+use ZaiClient\Security\ZaiHeaders;
 
 /**
  * Client for easy usage of Z.Ai recommendation API

--- a/tests/EventLogTest.php
+++ b/tests/EventLogTest.php
@@ -6,23 +6,24 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient;
+namespace ZaiClient\Tests;
 
 use PHPUnit\Framework\TestCase;
-use ZaiKorea\ZaiClient\Requests\PurchaseEvent;
-use ZaiKorea\ZaiClient\Requests\ProductDetailViewEvent;
-use ZaiKorea\ZaiClient\Requests\PageViewEvent;
-use ZaiKorea\ZaiClient\Requests\SearchEvent;
-use ZaiKorea\ZaiClient\Requests\LikeEvent;
-use ZaiKorea\ZaiClient\Requests\CartaddEvent;
-use ZaiKorea\ZaiClient\Requests\RateEvent;
-use ZaiKorea\ZaiClient\Requests\CustomEvent;
-use ZaiKorea\ZaiClient\Exceptions\ZaiClientException;
-use ZaiKorea\ZaiClient\Exceptions\BatchSizeLimitExceededException;
-use ZaiKorea\ZaiClient\Configs\Config;
 
+use ZaiClient\ZaiClient;
+use ZaiClient\Requests\PurchaseEvent;
+use ZaiClient\Requests\ProductDetailViewEvent;
+use ZaiClient\Requests\PageViewEvent;
+use ZaiClient\Requests\SearchEvent;
+use ZaiClient\Requests\LikeEvent;
+use ZaiClient\Requests\CartaddEvent;
+use ZaiClient\Requests\RateEvent;
+use ZaiClient\Requests\CustomEvent;
+use ZaiClient\Exceptions\ZaiClientException;
+use ZaiClient\Exceptions\BatchSizeLimitExceededException;
+use ZaiClient\Configs\Config;
+use ZaiClient\Tests\TestUtils;
 
-require_once 'TestUtils.php';
 
 class EventLogTest extends TestCase
 {
@@ -161,7 +162,7 @@ class EventLogTest extends TestCase
     {
         $client = new ZaiClient(self::CLIENT_ID, self::SECRET);
         $user_id = 'php-add-pageview';
-        $event_value = generateRandomString(503);
+        $event_value = TestUtils::generateRandomString(503);
 
         $page_view_event = new PageViewEvent($user_id, $event_value);
         $response = $client->addEventLog($page_view_event);
@@ -568,7 +569,7 @@ class EventLogTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $client = new ZaiClient(self::CLIENT_ID, self::SECRET);
-        $user_id = generateRandomString(101);
+        $user_id = TestUtils::generateRandomString(101);
 
         $item_id = ['P12345'];
         $view_event = new ProductDetailViewEvent($user_id, $item_id);
@@ -582,7 +583,7 @@ class EventLogTest extends TestCase
         $client = new ZaiClient(self::CLIENT_ID, self::SECRET);
         $user_id = 'php-raise-error';
 
-        $item_id = [generateRandomString(101)];
+        $item_id = [TestUtils::generateRandomString(101)];
         $view_event = new ProductDetailViewEvent($user_id, $item_id);
         $client->addEventLog($view_event);
     }
@@ -595,7 +596,7 @@ class EventLogTest extends TestCase
         $client = new ZaiClient(self::CLIENT_ID, self::SECRET);
         $user_id = 'php-raise-error';
 
-        $custom_event_type = generateRandomString(501);
+        $custom_event_type = TestUtils::generateRandomString(501);
         $custom_action = ['item_id' => 'P99999', 'value' => 9];
         $custom_event = new CustomEvent($user_id, $custom_event_type, $custom_action);
         $client->addEventLog($custom_event);

--- a/tests/RecommendationTest.php
+++ b/tests/RecommendationTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace ZaiKorea\ZaiClient;
+namespace ZaiClient;
 
 use PHPUnit\Framework\TestCase;
-use ZaiKorea\ZaiClient\Requests\UserRecommendationRequest;
-use ZaiKorea\ZaiClient\Requests\RelatedItemsRecommendationRequest;
-use ZaiKorea\ZaiClient\Requests\RerankingRecommendationRequest;
+use ZaiClient\Requests\UserRecommendationRequest;
+use ZaiClient\Requests\RelatedItemsRecommendationRequest;
+use ZaiClient\Requests\RerankingRecommendationRequest;
 
-require_once 'TestUtils.php';
+use ZaiClient\Tests\TestUtils;
 
 class RecommendationTest extends TestCase
 {
@@ -381,7 +381,7 @@ class RecommendationTest extends TestCase
         $limit = 3;
 
         $options = [
-            'recommendation_type' => generateRandomString(501),
+            'recommendation_type' => TestUtils::generateRandomString(501),
         ];
         new UserRecommendationRequest($user_id, $limit, $options);
     }

--- a/tests/ZaiclientTest.php
+++ b/tests/ZaiclientTest.php
@@ -6,20 +6,20 @@
  * @modifiedBy <name>
  */
 
-namespace ZaiKorea\ZaiClient;
+namespace ZaiClient;
 
 use PHPUnit\Framework\TestCase;
-use ZaiKorea\ZaiClient\Requests\PurchaseEvent;
-use ZaiKorea\ZaiClient\Requests\ProductDetailViewEvent;
-use ZaiKorea\ZaiClient\Requests\PageViewEvent;
-use ZaiKorea\ZaiClient\Requests\SearchEvent;
-use ZaiKorea\ZaiClient\Requests\LikeEvent;
-use ZaiKorea\ZaiClient\Requests\CartaddEvent;
-use ZaiKorea\ZaiClient\Requests\RateEvent;
-use ZaiKorea\ZaiClient\Requests\CustomEvent;
-use ZaiKorea\ZaiClient\Exceptions\ZaiClientException;
-use ZaiKorea\ZaiClient\Exceptions\BatchSizeLimitExceededException;
-use ZaiKorea\ZaiClient\Configs\Config;
+use ZaiClient\Requests\PurchaseEvent;
+use ZaiClient\Requests\ProductDetailViewEvent;
+use ZaiClient\Requests\PageViewEvent;
+use ZaiClient\Requests\SearchEvent;
+use ZaiClient\Requests\LikeEvent;
+use ZaiClient\Requests\CartaddEvent;
+use ZaiClient\Requests\RateEvent;
+use ZaiClient\Requests\CustomEvent;
+use ZaiClient\Exceptions\ZaiClientException;
+use ZaiClient\Exceptions\BatchSizeLimitExceededException;
+use ZaiClient\Configs\Config;
 
 class ZaiclientTest extends TestCase
 {


### PR DESCRIPTION
## What has changed
test code에서 별도의 TestUtils 클래스를 만들어서 사용하려고 했더니, php namespace 오류가 났습니다.
기존에 php namespace가 비직관적으로 되어 있고, convention에도 맞지 않아서 프로젝트 파일 구성을 src/ZaiClient/*에 있는 코드들을 src/* 로 1 level 올렸습니다.

역시 간단한 수정인데 코드 수정된 파일이 너무 많아서 별도 PR로 올립니다.

ps. 중간에 formatting 적용 안된 파일 1개에 대해서 포매팅이 적용된 부분이 있는데 이건 따로 PR 올리긴 너무 작아서 여기에 추가했습니다.